### PR TITLE
Data Dog Logger

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,5 @@ sudo: false
 language: ruby
 cache: bundler
 rvm:
-  - 2.3.0
-before_install: gem install bundler -v 1.17.1
+  - 2.6.6
+before_install: gem install bundler

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ datadog | increment | Hash | Hash of key-value pairs featuring the metric name a
 
 ```ruby
 # Sample usage
-EventTracer.info action: 'Action', message: 'Message', datadog: { increment: { counter_1: 1, counter_2: { value: 2, tag: ['foo']} } }
+EventTracer.info action: 'Action', message: 'Message', datadog: { increment: { counter_1: 1, counter_2: { value: 2, tags: ['foo']} } }
 # This calls .increment_counter on Datadog twice with the 2 sets of arguments
 #  counter_1, 1
 #  counter_2, 2

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ This gem currently supports only:
     1. increment_counter
     2. add_distribution_value
     3. set_gauge
+3. Datadog:  Empty wrapper around the custom metric distributions
+    1. increment
+    2. distribution
+    3. set
+    4. gauge
+    5. histogram    
 
 No dependencies are declared for this as the  
 
@@ -50,6 +56,7 @@ Each initialised logger is then registered to `EventTracer`.
 ```ruby
 EventTracer.register :base, base_logger
 EventTracer.register :appsignal, appsignal_logger
+EventTracer.register :datadog, datadog_logger
 ```
 
 As this is a registry, you can set it up with your own implemented wrapper as long as it responds to the following `LOG_TYPES` methods: `info, warn, error`
@@ -104,13 +111,43 @@ EventTracer.info action: 'Action', message: 'Message', appsignal: { increment_co
 #  counter_2, 2
 ```
 
+**3. Datadog**
+
+Datadog via dogstatsd-ruby (4.8.1) is currently supported for the following metric functions available for the EventTracer's log methods
+
+- increment
+- distribution
+- set
+- gauge
+- histogram
+
+All other functions are exposed transparently to the underlying Appsignal class
+
+The interface for using the Appsignal wrapper is:
+
+Key | Secondary key | Secondary key type | Values
+--------------|-------------|------------------|-------
+datadog | increment | Hash | Hash of key-value pairs featuring the metric name and the counter value to send
+| | distribution | Hash | Hash of key-value pairs featuring the metric name and the distribution value to send
+| | set | Hash | Hash of key-value pairs featuring the metric name and the set value to send
+| | gauge | Hash | Hash of key-value pairs featuring the metric name and the gauge value to send
+| | histogram | Hash | Hash of key-value pairs featuring the metric name and the histogram value to send
+
+```ruby
+# Sample usage
+EventTracer.info action: 'Action', message: 'Message', appsignal: { increment: { counter_1: 1, counter_2: 2 } }
+# This calls .increment_counter on Datadog twice with the 2 sets of arguments
+#  counter_1, 1
+#  counter_2, 2
+```
+
 **Summary**
 
 In all the generated interface for `EventTracer` logging could look something like this
 
 ```ruby
 EventTracer.info(
-  loggers: [:base, :appsignal, :custom_logging_service]
+  loggers: %(base appsignal custom_logging_service datadog),
   action: 'NewTransaction',
   message: "New transaction created by API",
   appsignal: {

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This gem currently supports only:
     2. add_distribution_value
     3. set_gauge
 3. Datadog:  Empty wrapper around the custom metric distributions
-    1. increment
+    1. count
     2. distribution
     3. set
     4. gauge
@@ -127,7 +127,7 @@ The interface for using the Appsignal wrapper is:
 
 Key | Secondary key | Secondary key type | Values
 --------------|-------------|------------------|-------
-datadog | increment | Hash | Hash of key-value pairs featuring the metric name and the counter value to send
+datadog | count | Hash | Hash of key-value pairs featuring the metric name and the counter value to send
 | | distribution | Hash | Hash of key-value pairs featuring the metric name and the distribution value to send
 | | set | Hash | Hash of key-value pairs featuring the metric name and the set value to send
 | | gauge | Hash | Hash of key-value pairs featuring the metric name and the gauge value to send
@@ -135,8 +135,8 @@ datadog | increment | Hash | Hash of key-value pairs featuring the metric name a
 
 ```ruby
 # Sample usage
-EventTracer.info action: 'Action', message: 'Message', datadog: { increment: { counter_1: 1, counter_2: { value: 2, tags: ['foo']} } }
-# This calls .increment_counter on Datadog twice with the 2 sets of arguments
+EventTracer.info action: 'Action', message: 'Message', datadog: { count: { counter_1: 1, counter_2: { value: 2, tags: ['foo']} } }
+# This calls .count on Datadog twice with the 2 sets of arguments
 #  counter_1, 1
 #  counter_2, 2
 ```

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ datadog | increment | Hash | Hash of key-value pairs featuring the metric name a
 
 ```ruby
 # Sample usage
-EventTracer.info action: 'Action', message: 'Message', appsignal: { increment: { counter_1: 1, counter_2: 2 } }
+EventTracer.info action: 'Action', message: 'Message', datadog: { increment: { counter_1: 1, counter_2: { value: 2, tag: ['foo']} } }
 # This calls .increment_counter on Datadog twice with the 2 sets of arguments
 #  counter_1, 1
 #  counter_2, 2
@@ -154,6 +154,12 @@ EventTracer.info(
     add_distribution_value: {
       "distribution_metric_1" => 1000,
       "distribution_metric_2" => 2000
+    }
+  },
+  datadog: {
+    distribution: {
+      "distribution_metric_1" => 1000,
+      "distribution_metric_2" => { value: 2000, tags: ['eu'] }
     }
   }
 )

--- a/event_tracer.gemspec
+++ b/event_tracer.gemspec
@@ -1,25 +1,24 @@
-# coding: utf-8
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "event_tracer/version"
+require 'event_tracer/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "event_tracer"
+  spec.name          = 'event_tracer'
   spec.version       = EventTracer::VERSION
-  spec.authors       = ["melvrickgoh"]
-  spec.email         = ["melvrickgoh@hotmail.com"]
+  spec.authors       = ['melvrickgoh']
+  spec.email         = ['melvrickgoh@hotmail.com']
 
-  spec.summary       = %q{Thin wrapper for formatted logging/ metric services to be used as a single service}
-  spec.description   = %q{Thin wrapper for formatted logging/ metric services to be used as a single service. External service(s) supported: Appsignal}
-  spec.homepage      = "https://github.com/melvrickgoh/event_tracer"
-  spec.license       = "MIT"
+  spec.summary       = 'Thin wrapper for formatted logging/ metric services to be used as a single service'
+  spec.description   = 'Thin wrapper for formatted logging/ metric services to be used as a single service. External service(s) supported: Appsignal'
+  spec.homepage      = 'https://github.com/melvrickgoh/event_tracer'
+  spec.license       = 'MIT'
 
   spec.files         = Dir['lib/**/*.rb']
-  spec.bindir        = "exe"
+  spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = ["lib/event_tracer", "lib"]
+  spec.require_paths = %w[lib/event_tracer lib]
 
-  spec.add_development_dependency "bundler", "~> 1.17"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency 'bundler', '~> 2.0'
+  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rspec', '~> 3.0'
 end

--- a/lib/event_tracer/datadog_logger.rb
+++ b/lib/event_tracer/datadog_logger.rb
@@ -44,7 +44,7 @@ module EventTracer
       payload.each do |increment, attribute|
         if attribute.is_a?(Hash)
           begin
-            datadog.send(
+            datadog.public_send(
               metric,
               increment,
               attribute.fetch(:value),
@@ -54,7 +54,7 @@ module EventTracer
             raise InvalidTagError, "Datadog payload { #{increment}: #{attribute} } invalid"
           end
         else
-          datadog.send(metric, increment, attribute)
+          datadog.public_send(metric, increment, attribute)
         end
       end
     end

--- a/lib/event_tracer/datadog_logger.rb
+++ b/lib/event_tracer/datadog_logger.rb
@@ -10,16 +10,15 @@ require_relative './basic_decorator'
 module EventTracer
   class DatadogLogger < BasicDecorator
 
-    SUPPORTED_METRICS ||= %i(increment set distribution gauge histogram).freeze
+    SUPPORTED_METRICS ||= %i[increment set distribution gauge histogram].freeze
 
     LOG_TYPES.each do |log_type|
       define_method log_type do |**args|
-        puts "args are: #{args}"
-        return LogResult.new(false, 'Invalid datadog config') unless args[:datadog] && args[:datadog].is_a?(Hash)
+        return LogResult.new(false, 'Invalid datadog config') unless args[:datadog]&.is_a?(Hash)
 
         applied_metrics(args[:datadog]).each do |metric|
           metric_args = args[:datadog][metric]
-          return LogResult.new(false, "Datadog metric #{metric} invalid") unless metric_args && metric_args.is_a?(Hash)
+          return LogResult.new(false, "Datadog metric #{metric} invalid") unless metric_args&.is_a?(Hash)
 
           send_metric metric, metric_args
         end
@@ -36,14 +35,6 @@ module EventTracer
     def applied_metrics(datadog_args)
       datadog_args.keys.select { |metric| SUPPORTED_METRICS.include?(metric) }
     end
-
-    # increment
-    # while true do
-    #   statsd.increment('example_metric.increment', tags: ['environment:dev'])
-    #   statsd.decrement('example_metric.decrement', tags: ['environment:dev'])
-    #   statsd.count('example_metric.count', 2, tags: ['environment:dev'])
-    #   sleep 10
-    # end
 
     def send_metric(metric, payload)
 

--- a/lib/event_tracer/datadog_logger.rb
+++ b/lib/event_tracer/datadog_logger.rb
@@ -25,8 +25,6 @@ module EventTracer
           return LogResult.new(false, "Datadog metric #{metric} invalid") unless metric_args.is_a?(Hash)
 
           send_metric metric, metric_args
-        rescue InvalidTagError => e
-          return LogResult.new(false, e.message)
         end
 
         LogResult.new(true)

--- a/lib/event_tracer/datadog_logger.rb
+++ b/lib/event_tracer/datadog_logger.rb
@@ -49,7 +49,7 @@ module EventTracer
               format_metric(metric),
               increment,
               attribute.fetch(:value),
-              build_options(attribute.dig(:tags))
+              build_options(attribute[:tags])
             )
           rescue KeyError
             raise InvalidTagError, "Datadog payload { #{increment}: #{attribute} } invalid"

--- a/lib/event_tracer/datadog_logger.rb
+++ b/lib/event_tracer/datadog_logger.rb
@@ -1,6 +1,5 @@
 require_relative '../event_tracer'
 require_relative './basic_decorator'
-require 'pry'
 # NOTES
 # Datadog interface to send our usual actions
 # BasicDecorator adds a transparent interface on top of the datadog interface

--- a/lib/event_tracer/datadog_logger.rb
+++ b/lib/event_tracer/datadog_logger.rb
@@ -39,10 +39,8 @@ module EventTracer
     def send_metric(metric, payload)
 
       payload.each do |increment, value|
-        puts "payload contains: increment: #{increment} value: #{value}"
         datadog.send(metric, increment, value)
       end
     end
-
   end
 end

--- a/lib/event_tracer/datadog_logger.rb
+++ b/lib/event_tracer/datadog_logger.rb
@@ -46,7 +46,7 @@ module EventTracer
         if attribute.is_a?(Hash)
           begin
             datadog.send(
-              metric,
+              format_metric(metric),
               increment,
               attribute.fetch(:value),
               format_tags(attribute.fetch(:tags))
@@ -55,7 +55,7 @@ module EventTracer
             raise InvalidTagError, "Datadog payload { #{increment}: #{attribute} } invalid"
           end
         else
-          datadog.send(metric, increment, attribute)
+          datadog.send(format_metric(metric), increment, attribute)
         end
       end
     end
@@ -66,6 +66,10 @@ module EventTracer
       tags.inject([]) do |acc, (tag, value)|
         acc << "#{tag}|#{value}"
       end
+    end
+
+    def format_metric(metric)
+      metric == :increment ? :count : metric
     end
   end
 end

--- a/lib/event_tracer/datadog_logger.rb
+++ b/lib/event_tracer/datadog_logger.rb
@@ -66,7 +66,7 @@ module EventTracer
           tags
         else
           tags.inject([]) do |acc, (tag, value)|
-            acc << "#{tag}|#{value}"
+            acc << "#{tag}:#{value}"
           end
         end
       { tags: formattted_tags }

--- a/lib/event_tracer/datadog_logger.rb
+++ b/lib/event_tracer/datadog_logger.rb
@@ -49,7 +49,7 @@ module EventTracer
               metric,
               increment,
               attribute.fetch(:value),
-              attribute.fetch(:tags)
+              format_tags(attribute.fetch(:tags))
             )
           rescue KeyError
             raise InvalidTagError, "Datadog payload { #{increment}: #{attribute} } invalid"
@@ -57,7 +57,14 @@ module EventTracer
         else
           datadog.send(metric, increment, attribute)
         end
+      end
+    end
 
+    def format_tags(tags)
+      return tags if tags.is_a?(Array)
+
+      tags.inject([]) do |acc, (tag, value)|
+        acc << "#{tag}|#{value}"
       end
     end
   end

--- a/lib/event_tracer/datadog_logger.rb
+++ b/lib/event_tracer/datadog_logger.rb
@@ -18,7 +18,7 @@ module EventTracer
 
         applied_metrics(args[:datadog]).each do |metric|
           metric_args = args[:datadog][metric]
-          return LogResult.new(false, "Datadog metric #{metric} invalid") unless metric_args&.is_a?(Hash)
+          return LogResult.new(false, "Datadog metric #{metric} invalid") unless metric_args.is_a?(Hash)
 
           send_metric metric, metric_args
         end

--- a/lib/event_tracer/datadog_logger.rb
+++ b/lib/event_tracer/datadog_logger.rb
@@ -1,0 +1,57 @@
+require_relative '../event_tracer'
+require_relative './basic_decorator'
+# NOTES
+# Datadog interface to send our usual actions
+# BasicDecorator adds a transparent interface on top of the datadog interface
+#
+# Usage: EventTracer.register :datadog, EventTracer::DataDogLogger.new(DataDog)
+#        data_dog_logger.info datadog: { increment: { counter_1: 1, counter_2: 2 }, set: { gauge_1: 1 } }
+
+module EventTracer
+  class DatadogLogger < BasicDecorator
+
+    SUPPORTED_METRICS ||= %i(increment set distribution gauge histogram).freeze
+
+    LOG_TYPES.each do |log_type|
+      define_method log_type do |**args|
+        puts "args are: #{args}"
+        return LogResult.new(false, 'Invalid datadog config') unless args[:datadog] && args[:datadog].is_a?(Hash)
+
+        applied_metrics(args[:datadog]).each do |metric|
+          metric_args = args[:datadog][metric]
+          return LogResult.new(false, "Datadog metric #{metric} invalid") unless metric_args && metric_args.is_a?(Hash)
+
+          send_metric metric, metric_args
+        end
+
+        LogResult.new(true)
+      end
+    end
+
+    private
+
+    attr_reader :datadog, :decoratee
+    alias_method :datadog, :decoratee
+
+    def applied_metrics(datadog_args)
+      datadog_args.keys.select { |metric| SUPPORTED_METRICS.include?(metric) }
+    end
+
+    # increment
+    # while true do
+    #   statsd.increment('example_metric.increment', tags: ['environment:dev'])
+    #   statsd.decrement('example_metric.decrement', tags: ['environment:dev'])
+    #   statsd.count('example_metric.count', 2, tags: ['environment:dev'])
+    #   sleep 10
+    # end
+
+    def send_metric(metric, payload)
+
+      payload.each do |increment, value|
+        puts "payload contains: increment: #{increment} value: #{value}"
+        datadog.send(metric, increment, value)
+      end
+    end
+
+  end
+end

--- a/lib/event_tracer/datadog_logger.rb
+++ b/lib/event_tracer/datadog_logger.rb
@@ -49,7 +49,7 @@ module EventTracer
               format_metric(metric),
               increment,
               attribute.fetch(:value),
-              format_tags(attribute.fetch(:tags))
+              build_options(attribute.dig(:tags))
             )
           rescue KeyError
             raise InvalidTagError, "Datadog payload { #{increment}: #{attribute} } invalid"
@@ -60,12 +60,18 @@ module EventTracer
       end
     end
 
-    def format_tags(tags)
-      return tags if tags.is_a?(Array)
+    def build_options(tags)
+      return {} unless tags
 
-      tags.inject([]) do |acc, (tag, value)|
-        acc << "#{tag}|#{value}"
-      end
+      formattted_tags =
+        if tags.is_a?(Array)
+          tags
+        else
+          tags.inject([]) do |acc, (tag, value)|
+            acc << "#{tag}|#{value}"
+          end
+        end
+      { tags: formattted_tags }
     end
 
     def format_metric(metric)

--- a/lib/event_tracer/version.rb
+++ b/lib/event_tracer/version.rb
@@ -1,3 +1,3 @@
 module EventTracer
-  VERSION = "0.1.2"
+  VERSION = '0.1.4'.freeze
 end

--- a/spec/data_helpers/mock_datadog.rb
+++ b/spec/data_helpers/mock_datadog.rb
@@ -1,0 +1,21 @@
+class MockDatadog < Struct.new(:_)
+  def increment(*_args)
+    'increment'
+  end
+
+  def distribution(*_args)
+    'distribution'
+  end
+
+  def set(*_args)
+    'set'
+  end
+
+  def gauge(*_args)
+    'gauge'
+  end
+
+  def histogram(*_args)
+    'histogram'
+  end
+end

--- a/spec/event_tracer/datadog_logger_spec.rb
+++ b/spec/event_tracer/datadog_logger_spec.rb
@@ -23,7 +23,7 @@ describe EventTracer::DatadogLogger do
       context 'processes_hashed_inputs' do
         let(:datadog_payload) do
           {
-            increment: { 'Counter_1' => 1, 'Counter_2' => 2 },
+            count: { 'Counter_1' => 1, 'Counter_2' => 2 },
             distribution: { 'Distribution_1' => 10 },
             set: { 'Set_1' => 100 },
             gauge: { 'Gauge_1' => 100 }
@@ -47,7 +47,7 @@ describe EventTracer::DatadogLogger do
       context 'processes_hashed_inputs with tags in correct format' do
         let(:datadog_payload) do
           {
-            increment: { 'Counter_1' => { value: 1 }, 'Counter_2' => { value: 2, tags: ['test']} },
+            count: { 'Counter_1' => { value: 1 }, 'Counter_2' => { value: 2, tags: ['test']} },
             distribution: { 'Distribution_1' => { value: 10, tags: ['test']} },
             set: { 'Set_1' => { value: 100, tags: ['test'] } },
             gauge: { 'Gauge_1' => { value: 100, tags: ['test'] } }
@@ -71,7 +71,7 @@ describe EventTracer::DatadogLogger do
       context 'processes_hashed_inputs with tags as hash' do
         let(:datadog_payload) do
           {
-            increment: {
+            count: {
               'Counter_1' => { value: 1 },
               'Counter_2' => { value: 2, tags: { test: 'value' } }
             },
@@ -115,7 +115,7 @@ describe EventTracer::DatadogLogger do
       context 'processes_hashed_inputs with value and tag is nil' do
         let(:datadog_payload) do
           {
-            increment: { 'Counter_1' => { value: 1, tag: nil } }
+            count: { 'Counter_1' => { value: 1, tag: nil } }
           }
         end
 
@@ -131,7 +131,7 @@ describe EventTracer::DatadogLogger do
       context 'processes_hashed_inputs with no value key' do
         let(:datadog_payload) do
           {
-            increment: { 'Counter_1' => { no_value: 1 } }
+            count: { 'Counter_1' => { no_value: 1 } }
           }
         end
 

--- a/spec/event_tracer/datadog_logger_spec.rb
+++ b/spec/event_tracer/datadog_logger_spec.rb
@@ -16,95 +16,90 @@ describe EventTracer::DatadogLogger do
 
   subject { EventTracer::DatadogLogger.new(mock_datadog) }
 
-  shared_examples_for 'rejects_invalid_datadog_args' do
-    INVALID_PAYLOADS.each do |datadog_value|
-      context "Invalid datadog top-level args" do
-        let(:datadog_payload) { datadog_value }
-
-        it 'rejects the payload when invalid datadog values are given' do
-          expect(mock_datadog).not_to receive(:increment)
-          expect(mock_datadog).not_to receive(:distribution)
-          expect(mock_datadog).not_to receive(:histogram)
-          expect(mock_datadog).not_to receive(:set)
-          expect(mock_datadog).not_to receive(:gauge)
-
-          result = subject.send(expected_call, datadog: datadog_payload)
-
-          expect(result.success?).to eq false
-          expect(result.error).to eq 'Invalid datadog config'
-        end
-      end
-    end
-  end
-
-  shared_examples_for 'skip_processing_empty_datadog_args' do
-    let(:datadog_payload) { {} }
-
-    it 'skips any metric processing' do
-      expect(mock_datadog).not_to receive(:increment_counter)
-      expect(mock_datadog).not_to receive(:add_distribution_value)
-      expect(mock_datadog).not_to receive(:set_gauge)
-
-      result = subject.send(expected_call, datadog: datadog_payload)
-
-      expect(result.success?).to eq true
-      expect(result.error).to eq nil
-    end
-  end
-
-  shared_examples_for 'processes_hashed_inputs' do
-    let(:datadog_payload) do
-      {
-        increment: { 'Counter_1' => 1, 'Counter_2' => 2 },
-        distribution: { 'Distribution_1' => 10 },
-        set: { 'Set_1' => 100 },
-        gauge: { 'Gauge_1' => 100 }
-      }
-    end
-
-    it 'processes each hash keyset as a metric iteration' do
-      expect(mock_datadog).to receive(:increment).with('Counter_1', 1)
-      expect(mock_datadog).to receive(:increment).with('Counter_2', 2)
-      expect(mock_datadog).to receive(:distribution).with('Distribution_1', 10)
-      expect(mock_datadog).to receive(:set).with('Set_1', 100)
-      expect(mock_datadog).to receive(:gauge).with('Gauge_1', 100)
-
-      result = subject.send(expected_call, datadog: datadog_payload)
-
-      expect(result.success?).to eq true
-      expect(result.error).to eq nil
-    end
-  end
-
-  shared_examples_for "rejects_invalid_metric_args" do
-    EventTracer::DatadogLogger::SUPPORTED_METRICS.each do |metric|
-      INVALID_PAYLOADS.each do |payload|
-        context "Invalid metric values for #{metric}: #{payload}" do
-          let(:datadog_payload) { { metric => payload } }
-
-          it 'rejects the payload when invalid datadog values are given' do
-            expect(mock_datadog).not_to receive(:increment_counter)
-            expect(mock_datadog).not_to receive(:add_distribution_value)
-            expect(mock_datadog).not_to receive(:set_gauge)
-
-            result = subject.send(expected_call, datadog: datadog_payload)
-
-            expect(result.success?).to eq false
-            expect(result.error).to eq "Datadog metric #{metric} invalid"
-          end
-        end
-      end
-    end
-  end
-
   EventTracer::LOG_TYPES.each do |log_type|
     context "Log type: #{log_type}" do
       let(:expected_call) { log_type }
 
-      it_behaves_like 'processes_hashed_inputs'
-      it_behaves_like 'skip_processing_empty_datadog_args'
-      it_behaves_like 'rejects_invalid_datadog_args'
-      it_behaves_like 'rejects_invalid_metric_args'
+      context 'processes_hashed_inputs' do
+        let(:datadog_payload) do
+          {
+            increment: { 'Counter_1' => 1, 'Counter_2' => 2 },
+            distribution: { 'Distribution_1' => 10 },
+            set: { 'Set_1' => 100 },
+            gauge: { 'Gauge_1' => 100 }
+          }
+        end
+
+        it 'processes each hash keyset as a metric iteration' do
+          expect(mock_datadog).to receive(:increment).with('Counter_1', 1)
+          expect(mock_datadog).to receive(:increment).with('Counter_2', 2)
+          expect(mock_datadog).to receive(:distribution).with('Distribution_1', 10)
+          expect(mock_datadog).to receive(:set).with('Set_1', 100)
+          expect(mock_datadog).to receive(:gauge).with('Gauge_1', 100)
+
+          result = subject.send(expected_call, datadog: datadog_payload)
+
+          expect(result.success?).to eq true
+          expect(result.error).to eq nil
+        end
+      end
+
+      context 'skip_processing_empty_datadog_args' do
+        let(:datadog_payload) { {} }
+
+        it 'skips any metric processing' do
+          expect(mock_datadog).not_to receive(:increment_counter)
+          expect(mock_datadog).not_to receive(:add_distribution_value)
+          expect(mock_datadog).not_to receive(:set_gauge)
+
+          result = subject.send(expected_call, datadog: datadog_payload)
+
+          expect(result.success?).to eq true
+          expect(result.error).to eq nil
+        end
+      end
+
+      context 'rejects_invalid_datadog_args' do
+        INVALID_PAYLOADS.each do |datadog_value|
+          context 'Invalid datadog top-level args' do
+            let(:datadog_payload) { datadog_value }
+
+            it 'rejects the payload when invalid datadog values are given' do
+              expect(mock_datadog).not_to receive(:increment)
+              expect(mock_datadog).not_to receive(:distribution)
+              expect(mock_datadog).not_to receive(:histogram)
+              expect(mock_datadog).not_to receive(:set)
+              expect(mock_datadog).not_to receive(:gauge)
+
+              result = subject.send(expected_call, datadog: datadog_payload)
+
+              expect(result.success?).to eq false
+              expect(result.error).to eq 'Invalid datadog config'
+            end
+          end
+        end
+      end
+
+      context 'rejects_invalid_metric_args' do
+        EventTracer::DatadogLogger::SUPPORTED_METRICS.each do |metric|
+          INVALID_PAYLOADS.each do |payload|
+            context "Invalid metric values for #{metric}: #{payload}" do
+              let(:datadog_payload) { { metric => payload } }
+
+              it 'rejects the payload when invalid datadog values are given' do
+                expect(mock_datadog).not_to receive(:increment_counter)
+                expect(mock_datadog).not_to receive(:add_distribution_value)
+                expect(mock_datadog).not_to receive(:set_gauge)
+
+                result = subject.send(expected_call, datadog: datadog_payload)
+
+                expect(result.success?).to eq false
+                expect(result.error).to eq "Datadog metric #{metric} invalid"
+              end
+            end
+          end
+        end
+      end
     end
   end
 end

--- a/spec/event_tracer/datadog_logger_spec.rb
+++ b/spec/event_tracer/datadog_logger_spec.rb
@@ -31,8 +31,8 @@ describe EventTracer::DatadogLogger do
         end
 
         it 'processes each hash keyset as a metric iteration' do
-          expect(mock_datadog).to receive(:increment).with('Counter_1', 1)
-          expect(mock_datadog).to receive(:increment).with('Counter_2', 2)
+          expect(mock_datadog).to receive(:count).with('Counter_1', 1)
+          expect(mock_datadog).to receive(:count).with('Counter_2', 2)
           expect(mock_datadog).to receive(:distribution).with('Distribution_1', 10)
           expect(mock_datadog).to receive(:set).with('Set_1', 100)
           expect(mock_datadog).to receive(:gauge).with('Gauge_1', 100)
@@ -55,8 +55,8 @@ describe EventTracer::DatadogLogger do
         end
 
         it 'processes each hash keyset as a metric iteration' do
-          expect(mock_datadog).to receive(:increment).with('Counter_1', 1, ['test'])
-          expect(mock_datadog).to receive(:increment).with('Counter_2', 2, ['test'])
+          expect(mock_datadog).to receive(:count).with('Counter_1', 1, ['test'])
+          expect(mock_datadog).to receive(:count).with('Counter_2', 2, ['test'])
           expect(mock_datadog).to receive(:distribution).with('Distribution_1', 10, ['test'])
           expect(mock_datadog).to receive(:set).with('Set_1', 100, ['test'])
           expect(mock_datadog).to receive(:gauge).with('Gauge_1', 100, ['test'])
@@ -82,8 +82,8 @@ describe EventTracer::DatadogLogger do
         end
 
         it 'processes each hash keyset as a metric iteration' do
-          expect(mock_datadog).to receive(:increment).with('Counter_1', 1, ['test|value'])
-          expect(mock_datadog).to receive(:increment).with('Counter_2', 2, ['test|value'])
+          expect(mock_datadog).to receive(:count).with('Counter_1', 1, ['test|value'])
+          expect(mock_datadog).to receive(:count).with('Counter_2', 2, ['test|value'])
           expect(mock_datadog).to receive(:distribution).with('Distribution_1', 10, ['test|value'])
           expect(mock_datadog).to receive(:set).with('Set_1', 100, ['test|value'])
           expect(mock_datadog).to receive(:gauge).with('Gauge_1', 100, ['test|value'])
@@ -118,7 +118,7 @@ describe EventTracer::DatadogLogger do
         end
 
         it 'processes each hash keyset as a metric iteration' do
-          expect(mock_datadog).not_to receive(:increment).with('Counter_1', 1)
+          expect(mock_datadog).not_to receive(:count).with('Counter_1', 1)
 
           result = subject.send(expected_call, datadog: datadog_payload)
 
@@ -133,7 +133,7 @@ describe EventTracer::DatadogLogger do
             let(:datadog_payload) { datadog_value }
 
             it 'rejects the payload when invalid datadog values are given' do
-              expect(mock_datadog).not_to receive(:increment)
+              expect(mock_datadog).not_to receive(:count)
               expect(mock_datadog).not_to receive(:distribution)
               expect(mock_datadog).not_to receive(:histogram)
               expect(mock_datadog).not_to receive(:set)

--- a/spec/event_tracer/datadog_logger_spec.rb
+++ b/spec/event_tracer/datadog_logger_spec.rb
@@ -1,0 +1,110 @@
+require 'spec_helper'
+
+describe EventTracer::DatadogLogger do
+
+  INVALID_PAYLOADS ||= [
+    nil,
+    [],
+    Object.new,
+    'string',
+    10,
+    :invalid_payload
+  ].freeze
+
+  let(:datadog_payload) { nil }
+  let(:mock_datadog) { MockDatadog.new }
+
+  subject { EventTracer::DatadogLogger.new(mock_datadog) }
+
+  shared_examples_for 'rejects_invalid_datadog_args' do
+    INVALID_PAYLOADS.each do |datadog_value|
+      context "Invalid datadog top-level args" do
+        let(:datadog_payload) { datadog_value }
+
+        it 'rejects the payload when invalid datadog values are given' do
+          expect(mock_datadog).not_to receive(:increment)
+          expect(mock_datadog).not_to receive(:distribution)
+          expect(mock_datadog).not_to receive(:histogram)
+          expect(mock_datadog).not_to receive(:set)
+          expect(mock_datadog).not_to receive(:gauge)
+
+          result = subject.send(expected_call, datadog: datadog_payload)
+
+          expect(result.success?).to eq false
+          expect(result.error).to eq 'Invalid datadog config'
+        end
+      end
+    end
+  end
+
+  shared_examples_for 'skip_processing_empty_datadog_args' do
+    let(:datadog_payload) { {} }
+
+    it 'skips any metric processing' do
+      expect(mock_datadog).not_to receive(:increment_counter)
+      expect(mock_datadog).not_to receive(:add_distribution_value)
+      expect(mock_datadog).not_to receive(:set_gauge)
+
+      result = subject.send(expected_call, datadog: datadog_payload)
+
+      expect(result.success?).to eq true
+      expect(result.error).to eq nil
+    end
+  end
+
+  shared_examples_for 'processes_hashed_inputs' do
+    let(:datadog_payload) do
+      {
+        increment: { 'Counter_1' => 1, 'Counter_2' => 2 },
+        distribution: { 'Distribution_1' => 10 },
+        set: { 'Set_1' => 100 },
+        gauge: { 'Gauge_1' => 100 }
+      }
+    end
+
+    it 'processes each hash keyset as a metric iteration' do
+      expect(mock_datadog).to receive(:increment).with('Counter_1', 1)
+      expect(mock_datadog).to receive(:increment).with('Counter_2', 2)
+      expect(mock_datadog).to receive(:distribution).with('Distribution_1', 10)
+      expect(mock_datadog).to receive(:set).with('Set_1', 100)
+      expect(mock_datadog).to receive(:gauge).with('Gauge_1', 100)
+
+      result = subject.send(expected_call, datadog: datadog_payload)
+
+      expect(result.success?).to eq true
+      expect(result.error).to eq nil
+    end
+  end
+
+  shared_examples_for "rejects_invalid_metric_args" do
+    EventTracer::DatadogLogger::SUPPORTED_METRICS.each do |metric|
+      INVALID_PAYLOADS.each do |payload|
+        context "Invalid metric values for #{metric}: #{payload}" do
+          let(:datadog_payload) { { metric => payload } }
+
+          it 'rejects the payload when invalid datadog values are given' do
+            expect(mock_datadog).not_to receive(:increment_counter)
+            expect(mock_datadog).not_to receive(:add_distribution_value)
+            expect(mock_datadog).not_to receive(:set_gauge)
+
+            result = subject.send(expected_call, datadog: datadog_payload)
+
+            expect(result.success?).to eq false
+            expect(result.error).to eq "Datadog metric #{metric} invalid"
+          end
+        end
+      end
+    end
+  end
+
+  EventTracer::LOG_TYPES.each do |log_type|
+    context "Log type: #{log_type}" do
+      let(:expected_call) { log_type }
+
+      it_behaves_like 'processes_hashed_inputs'
+      it_behaves_like 'skip_processing_empty_datadog_args'
+      it_behaves_like 'rejects_invalid_datadog_args'
+      it_behaves_like 'rejects_invalid_metric_args'
+    end
+  end
+end

--- a/spec/event_tracer/datadog_logger_spec.rb
+++ b/spec/event_tracer/datadog_logger_spec.rb
@@ -128,23 +128,6 @@ describe EventTracer::DatadogLogger do
         end
       end
 
-      context 'processes_hashed_inputs with no value key' do
-        let(:datadog_payload) do
-          {
-            count: { 'Counter_1' => { no_value: 1 } }
-          }
-        end
-
-        it 'processes each hash keyset as a metric iteration' do
-          expect(mock_datadog).not_to receive(:count).with('Counter_1', 1)
-
-          result = subject.send(expected_call, datadog: datadog_payload)
-
-          expect(result.success?).to eq false
-          expect(result.error).to eq 'Datadog payload { Counter_1: {:no_value=>1} } invalid'
-        end
-      end
-
       context 'rejects_invalid_datadog_args' do
         INVALID_PAYLOADS.each do |datadog_value|
           context 'Invalid datadog top-level args' do

--- a/spec/event_tracer/datadog_logger_spec.rb
+++ b/spec/event_tracer/datadog_logger_spec.rb
@@ -83,10 +83,10 @@ describe EventTracer::DatadogLogger do
 
         it 'processes each hash keyset as a metric iteration' do
           expect(mock_datadog).to receive(:count).with('Counter_1', 1, {})
-          expect(mock_datadog).to receive(:count).with('Counter_2', 2, tags: ['test|value'])
-          expect(mock_datadog).to receive(:distribution).with('Distribution_1', 10, tags: ['test|value'])
-          expect(mock_datadog).to receive(:set).with('Set_1', 100, tags: ['test|value'])
-          expect(mock_datadog).to receive(:gauge).with('Gauge_1', 100, tags: ['test|value'])
+          expect(mock_datadog).to receive(:count).with('Counter_2', 2, tags: ['test:value'])
+          expect(mock_datadog).to receive(:distribution).with('Distribution_1', 10, tags: ['test:value'])
+          expect(mock_datadog).to receive(:set).with('Set_1', 100, tags: ['test:value'])
+          expect(mock_datadog).to receive(:gauge).with('Gauge_1', 100, tags: ['test:value'])
 
           result = subject.send(expected_call, datadog: datadog_payload)
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,12 @@
-require "bundler/setup"
-require "event_tracer"
-require "data_helpers/mock_logger"
-require "data_helpers/mock_appsignal"
+require 'bundler/setup'
+require 'event_tracer'
+require 'data_helpers/mock_logger'
+require 'data_helpers/mock_appsignal'
+require 'data_helpers/mock_datadog'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
-  config.example_status_persistence_file_path = ".rspec_status"
+  config.example_status_persistence_file_path = '.rspec_status'
 
   config.expect_with :rspec do |c|
     c.syntax = :expect


### PR DESCRIPTION
- supports the following metrics:
    1. increment
    2. distribution
    3. set
    4. gauge
    5. histogram    

Tested using MC with the following setup:

```
statsd = Datadog::Statsd.new('localhost', 8125)
EventTracer.register :datadog, EventTracer::DatadogLogger.new(statsd)
```
caveat: local datadog agent needs to be up and running to send data 

sample events triggered:
![Screen Shot 2020-10-13 at 11 03 38 AM](https://user-images.githubusercontent.com/467007/95810666-18cda680-0d44-11eb-8599-d4e9d8d2251d.png)
