### PR TITLE
Support ruby 3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /pkg/
 /spec/reports/
 /tmp/
+/vendor/bundle/
 *.gem
 Gemfile.lock
 

--- a/event_tracer.gemspec
+++ b/event_tracer.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = %w[lib/event_tracer lib]
 
-  spec.add_development_dependency "bundler", "~> 2.1.4"
+  spec.add_development_dependency "bundler", ">= 2.1.4"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 end

--- a/lib/event_tracer.rb
+++ b/lib/event_tracer.rb
@@ -33,7 +33,7 @@ module EventTracer
       loggers.each do |code, logger|
         begin
           if args[:action] && args[:message]
-            result.record code, logger.send(log_type, filtered_log_arguments(code, args))
+            result.record code, logger.send(log_type, **filtered_log_arguments(code, args))
           else
             result.record code, LogResult.new(false, 'Fields action & message need to be populated')
           end

--- a/lib/event_tracer/base_logger.rb
+++ b/lib/event_tracer/base_logger.rb
@@ -7,8 +7,8 @@ module EventTracer
   class BaseLogger < BasicDecorator
 
     LOG_TYPES.each do |log_type|
-      define_method log_type do |*args|
-        send_message(log_type, *args)
+      define_method log_type do |**args|
+        send_message(log_type, **args)
         LogResult.new(true)
       end
     end

--- a/lib/event_tracer/basic_decorator.rb
+++ b/lib/event_tracer/basic_decorator.rb
@@ -1,3 +1,5 @@
+require 'delegate'
+
 module EventTracer
   class BasicDecorator < Delegator
 


### PR DESCRIPTION
- `delegate` must be required before using
- keyword parameters as hash is deprecated