### PR TITLE
Support ruby 2.6 & 2.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+on: [push, pull_request]
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - "3.0"
+          - "2.7"
+          - "2.6"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: Run unit tests
+        run: bundle exec rspec

--- a/lib/event_tracer/base_logger.rb
+++ b/lib/event_tracer/base_logger.rb
@@ -20,7 +20,8 @@ module EventTracer
 
       # EventTracer ensures action & message is always populated
       def send_message(log_method, action:, message:, **args)
-        data = args.merge(action: action, message: message).except(:metrics)
+        args.delete(:metrics)
+        data = args.merge(action: action, message: message)
         logger.public_send(log_method, data)
       end
 

--- a/lib/event_tracer/version.rb
+++ b/lib/event_tracer/version.rb
@@ -1,3 +1,3 @@
 module EventTracer
-  VERSION = '0.3.0'.freeze
+  VERSION = '0.3.1'.freeze
 end


### PR DESCRIPTION
`except` is only available in ruby 3, so we should replace it with `delete` to support ruby 2.6 & 2.7