### PR TITLE
Allow configuring dynamodb client without monkey-patching

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ require 'event_tracer/dynamo_db/logger'
 EventTracer::Config.configure do |config|
   config.app_name = 'guardhouse'.freeze # app name that will be sent with each log to DynamoDB
   config.dynamo_db_table_name = ENV.fetch('AWS_DYNAMODB_LOGGING_TABLE', 'logs') # send logs to this DynamoDB table
+  config.dynamo_db_client = Aws::DynamoDB::Client.new # this value is set by default
 end
 ```
 

--- a/lib/event_tracer.rb
+++ b/lib/event_tracer.rb
@@ -3,7 +3,7 @@ require 'event_tracer/log_result'
 
 module EventTracer
 
-  LOG_TYPES ||= %i(info warn error)
+  LOG_TYPES = %i(info warn error)
 
   @loggers = {}
 

--- a/lib/event_tracer/config.rb
+++ b/lib/event_tracer/config.rb
@@ -5,6 +5,9 @@ module EventTracer
     extend Dry::Configurable
 
     setting :app_name, default: 'app_name'
+
+    # TODO: switch to namespace in v1.0
     setting :dynamo_db_table_name, default: 'logs'
+    setting :dynamo_db_client
   end
 end

--- a/lib/event_tracer/dynamo_db/client.rb
+++ b/lib/event_tracer/dynamo_db/client.rb
@@ -1,9 +1,13 @@
-# TODO: move this into logger class in v1.0
 module EventTracer
   module DynamoDB
     class Client
-      def self.call
-        EventTracer::Config.dynamo_db_client || Aws::DynamoDB::Client.new
+      class << self
+        extend Gem::Deprecate
+
+        def call
+          Aws::DynamoDB::Client.new
+        end
+        deprecate :call, 'EventTracer::Config.config.dynamo_db_client', 2021, 12
       end
     end
   end

--- a/lib/event_tracer/dynamo_db/client.rb
+++ b/lib/event_tracer/dynamo_db/client.rb
@@ -1,8 +1,9 @@
+# TODO: move this into logger class in v1.0
 module EventTracer
   module DynamoDB
     class Client
       def self.call
-        Aws::DynamoDB::Client.new
+        EventTracer::Config.dynamo_db_client || Aws::DynamoDB::Client.new
       end
     end
   end

--- a/lib/event_tracer/version.rb
+++ b/lib/event_tracer/version.rb
@@ -1,3 +1,3 @@
 module EventTracer
-  VERSION = '0.4.0'.freeze
+  VERSION = '0.4.1'.freeze
 end

--- a/spec/event_tracer/appsignal_logger_spec.rb
+++ b/spec/event_tracer/appsignal_logger_spec.rb
@@ -2,13 +2,13 @@ require 'spec_helper'
 
 describe EventTracer::AppsignalLogger do
 
-  INVALID_METRIC_TYPES = [
+  self::INVALID_METRIC_TYPES = [
     nil,
     Object.new,
     10
   ].freeze
 
-  NON_WHITELISTED_METRIC_TYPES = [
+  self::NON_WHITELISTED_METRIC_TYPES = [
     :invalid_payload,
     :count,
     'set',
@@ -34,7 +34,7 @@ describe EventTracer::AppsignalLogger do
   end
 
   shared_examples_for 'skip_logging_non_whitelisted_metric_types' do
-    NON_WHITELISTED_METRIC_TYPES.each do |type|
+    self::NON_WHITELISTED_METRIC_TYPES.each do |type|
       context "non whitelisted metric types" do
         let(:params) do
           {
@@ -61,7 +61,7 @@ describe EventTracer::AppsignalLogger do
   end
 
   shared_examples_for "rejects_invalid_appsignal_metric_type" do
-    INVALID_METRIC_TYPES.each do |type|
+    self::INVALID_METRIC_TYPES.each do |type|
       context "Invalid metric values for #{type} type" do
         let(:params) do
           {

--- a/spec/event_tracer/datadog_logger_spec.rb
+++ b/spec/event_tracer/datadog_logger_spec.rb
@@ -2,13 +2,13 @@ require 'spec_helper'
 
 describe EventTracer::DatadogLogger do
 
-  INVALID_METRIC_TYPES = [
+  self::INVALID_METRIC_TYPES = [
     nil,
     Object.new,
     10
   ].freeze
 
-  NON_WHITELISTED_METRIC_TYPES = [
+  self::NON_WHITELISTED_METRIC_TYPES = [
     :invalid_payload,
     :add_distribution_value,
     'increment_counter',
@@ -37,7 +37,7 @@ describe EventTracer::DatadogLogger do
   end
 
   shared_examples_for "skip_logging_non_whitelisted_metric_types" do
-    NON_WHITELISTED_METRIC_TYPES.each do |type|
+    self::NON_WHITELISTED_METRIC_TYPES.each do |type|
       context "Invalid metric values for #{type} type" do
         let(:params) do
           {
@@ -66,7 +66,7 @@ describe EventTracer::DatadogLogger do
   end
 
   shared_examples_for 'rejects_invalid_datadog_metric_types' do
-    INVALID_METRIC_TYPES.each do |type|
+    self::INVALID_METRIC_TYPES.each do |type|
       context "Invalid appsignal top-level args" do
         let(:params) do
           {

--- a/spec/event_tracer/dynamo_db/worker_spec.rb
+++ b/spec/event_tracer/dynamo_db/worker_spec.rb
@@ -8,11 +8,7 @@ describe EventTracer::DynamoDB::Worker do
     })
   end
 
-  before do
-    allow(EventTracer::DynamoDB::Client).to receive(:call) { aws_dynamo_client }
-  end
-
-  subject { described_class.new }
+  subject { described_class.new(aws_dynamo_client) }
 
   context 'when input is a single item' do
     let(:batch_write_item) { true }


### PR DESCRIPTION
Currently we need to monkey patch `EventTracer::DynamoDB::Client` in order to have custom behavior for test. This PR fixes that by allowing configuration via `EventTracer::Config`.

In the future, we can make `Aws::DynamoDB::Client.new` the default value and remove `EventTracer::DynamoDB::Client`. Moreover, now that we have more config for dynamoDB, it's probably better for us to switch to namespace for clarity.

This PR also fix some warnings about constant leaking in test.