### PR TITLE
fix/update readme and handle different queue name

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,13 +170,14 @@ EventTracer.info action: 'Action', message: 'Message',
 
 Before using this logger, you need to require the logger and define some config:
 ```ruby
-require 'event_tracer/dynamo_db/logger'
-
 EventTracer::Config.configure do |config|
   config.app_name = 'guardhouse'.freeze # app name that will be sent with each log to DynamoDB
   config.dynamo_db_table_name = ENV.fetch('AWS_DYNAMODB_LOGGING_TABLE', 'logs') # send logs to this DynamoDB table
   config.dynamo_db_client = Aws::DynamoDB::Client.new # this value is set by default
+  config.dynamo_db_queue_name = 'low' # defaults to 'low'
 end
+
+require "event_tracer/dynamo_db/logger" # NOTE: needs to be required after configuring EventTracer
 ```
 
 **Preparing payload (optional)**

--- a/lib/event_tracer/config.rb
+++ b/lib/event_tracer/config.rb
@@ -9,5 +9,6 @@ module EventTracer
     # TODO: switch to namespace in v1.0
     setting :dynamo_db_table_name, default: 'logs'
     setting :dynamo_db_client
+    setting :dynamo_db_queue_name, default: 'low'
   end
 end

--- a/lib/event_tracer/dynamo_db/worker.rb
+++ b/lib/event_tracer/dynamo_db/worker.rb
@@ -15,7 +15,7 @@ module EventTracer
     class Worker
       include ::Sidekiq::Worker
 
-      sidekiq_options retry: 1, queue: 'low'
+      sidekiq_options retry: 1, queue: EventTracer::Config.config.dynamo_db_queue_name
 
       # See https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/DynamoDB/Client.html#batch_write_item-instance_method
       MAX_DYNAMO_DB_ITEM_PER_REQUEST = 25

--- a/lib/event_tracer/version.rb
+++ b/lib/event_tracer/version.rb
@@ -1,3 +1,3 @@
 module EventTracer
-  VERSION = '0.4.1'.freeze
+  VERSION = '0.5.0'.freeze
 end

--- a/lib/event_tracer/version.rb
+++ b/lib/event_tracer/version.rb
@@ -1,3 +1,3 @@
 module EventTracer
-  VERSION = '0.5.0'.freeze
+  VERSION = '0.4.2'.freeze
 end


### PR DESCRIPTION
This fixes two things:
1. README: Configuration needs to be set before dynamo_db logger is required, so that the logger can access the correct values
2. Other apps do not always have the `'low'` queue, so this PR allows this option to be configured