### PR TITLE
[GHP-1134] Handle malform json in input

### DIFF
--- a/lib/event_tracer/buffered_logger.rb
+++ b/lib/event_tracer/buffered_logger.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'time'
+
+module EventTracer
+  class BufferedLogger
+    def initialize(log_processor:, worker:, buffer: Buffer.new(buffer_size: 0))
+      @buffer = buffer
+      @worker = worker
+      @log_processor = log_processor
+    end
+
+    EventTracer::LOG_TYPES.each do |log_type|
+      define_method log_type do |**args|
+        save_message log_type, **args
+      end
+    end
+
+    private
+
+    attr_reader :buffer, :log_processor, :worker
+
+    def save_message(log_type, action:, message:, **args)
+      payload = log_processor.call(log_type, action: action, message: message, args: args)
+
+      unless buffer.add(payload)
+        all_payloads = buffer.flush + [payload]
+        execute_payload(all_payloads)
+      end
+
+      LogResult.new(true)
+    end
+
+    def execute_payload(payloads)
+      worker.perform_async(payloads)
+    rescue JSON::GeneratorError => e
+      filtered_payloads = filter_invalid_data(payloads)
+
+      EventTracer.warn(
+        loggers: %i(base),
+        action: self.class.name,
+        app: EventTracer::Config.config.app_name,
+        error: e.class.name,
+        message: e.message,
+        payload: payloads - filtered_payloads
+      )
+
+      worker.perform_async(filtered_payloads) if filtered_payloads.any?
+    end
+
+    def filter_invalid_data(payloads)
+      payloads.select { |payload| payload.to_json rescue false }
+    end
+  end
+end

--- a/lib/event_tracer/dynamo_db/logger.rb
+++ b/lib/event_tracer/dynamo_db/logger.rb
@@ -7,33 +7,10 @@ require_relative 'default_processor'
 
 module EventTracer
   module DynamoDB
-    class Logger
+    class Logger < BufferedLogger
       def initialize(buffer: Buffer.new(buffer_size: 0), log_processor: DefaultProcessor.new)
-        @buffer = buffer
-        @log_processor = log_processor
+        super(buffer: buffer, log_processor: log_processor, worker: Worker)
       end
-
-      EventTracer::LOG_TYPES.each do |log_type|
-        define_method log_type do |**args|
-          save_message log_type, **args
-        end
-      end
-
-      private
-
-        attr_reader :buffer, :log_processor
-
-        def save_message(log_type, action:, message:, **args)
-          payload = log_processor.call(log_type, action: action, message: message, args: args)
-
-          unless buffer.add(payload)
-            all_payloads = buffer.flush + [payload]
-            Worker.perform_async(all_payloads)
-          end
-
-          LogResult.new(true)
-        end
-
     end
   end
 end

--- a/lib/event_tracer/version.rb
+++ b/lib/event_tracer/version.rb
@@ -1,3 +1,3 @@
 module EventTracer
-  VERSION = '0.4.1'.freeze
+  VERSION = '0.4.2'.freeze
 end

--- a/spec/event_tracer/buffered_logger_spec.rb
+++ b/spec/event_tracer/buffered_logger_spec.rb
@@ -1,0 +1,58 @@
+describe EventTracer::BufferedLogger do
+  let(:buffer) { instance_double(EventTracer::Buffer) }
+  let(:log_processor) { double('LogProcessor') }
+  let(:worker) { double('Worker') }
+  let(:logger) do
+    described_class.new(
+      buffer: buffer,
+      log_processor: log_processor,
+      worker: worker
+    )
+  end
+  let(:action) { 'Action' }
+  let(:message) { 'this is a message' }
+  let(:args) { { random_data: 'random' } }
+  let(:payload) { { data: 'data' } }
+  subject { logger.info(action: action, message: message, **args) }
+
+  before do
+    expect(log_processor).to receive(:call)
+      .with(:info, action: action, message: message, args: args).and_return(payload)
+  end
+
+  context 'when buffer is not full' do
+    before do
+      expect(buffer).to receive(:add).with(payload).and_return(true)
+    end
+
+    it { is_expected.to be_success }
+  end
+
+  context 'when buffer is full and there are no JSON error' do
+    let(:all_payloads) { [other_payload, payload] }
+    let(:other_payload) { { data: 'other' } }
+
+    before do
+      expect(buffer).to receive(:add).with(payload).and_return(false)
+      expect(buffer).to receive(:flush).and_return([other_payload])
+      expect(worker).to receive(:perform_async).with(all_payloads)
+    end
+
+    it { is_expected.to be_success }
+  end
+
+  context 'when buffer is full and there is JSON generator error' do
+    let(:all_payloads) { [other_payload, payload] }
+    let(:other_payload) { { data: "\xAE" } }
+
+    before do
+      expect(buffer).to receive(:add).with(payload).and_return(false)
+      expect(buffer).to receive(:flush).and_return([other_payload])
+      expect(worker).to receive(:perform_async)
+        .with(all_payloads).and_raise(JSON::GeneratorError)
+      expect(worker).to receive(:perform_async).with([payload])
+    end
+
+    it { is_expected.to be_success }
+  end
+end


### PR DESCRIPTION
# Context

There are cases when input contains invalid UTF-8 character, then error blows up when we try to parse it to JSON when logging to DynamoDB worker. 

This update introduces `BufferedLogger`, which can be inherited by any loggers that depend on Sidekiq. It automatic strips out all bad input upon JSON generation error and log them using BaseLogger.

# Caveat

Because we only strip out bad input upon failed json generation, tail latency in certain request could be bad, due to:
- Generate JSON for each payload to filter out bad data
- Sidekiq pushes data to redis again

However, comparing to other options, this one seems to be the best, considering bad input is a minority:
- Check for valid JSON for every payload - this slows down every request, even the one that can render valid JSON
- Filter valid string for every input - this is time-consuming and may not filter all possible invalid input