### PR TITLE
Clean up the code to remove warnings from ruby interpreter

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,4 @@
 --format documentation
 --color
 --require spec_helper
+--warnings

--- a/lib/event_tracer/appsignal_logger.rb
+++ b/lib/event_tracer/appsignal_logger.rb
@@ -1,4 +1,3 @@
-require_relative '../event_tracer'
 require_relative './basic_decorator'
 
 # NOTES
@@ -55,7 +54,6 @@ module EventTracer
 
     private
 
-      attr_reader :decoratee
       alias_method :appsignal, :decoratee
 
       def valid_args?(metrics)

--- a/lib/event_tracer/base_logger.rb
+++ b/lib/event_tracer/base_logger.rb
@@ -1,4 +1,3 @@
-require_relative '../event_tracer'
 require_relative './basic_decorator'
 require 'json'
 
@@ -15,7 +14,6 @@ module EventTracer
 
     private
 
-      attr_reader :logger, :decoratee
       alias_method :logger, :decoratee
 
       # EventTracer ensures action & message is always populated

--- a/lib/event_tracer/basic_decorator.rb
+++ b/lib/event_tracer/basic_decorator.rb
@@ -24,5 +24,8 @@ module EventTracer
       LogResult.new(false, message)
     end
 
+    private
+
+    attr_reader :decoratee
   end
 end

--- a/lib/event_tracer/datadog_logger.rb
+++ b/lib/event_tracer/datadog_logger.rb
@@ -1,4 +1,3 @@
-require_relative '../event_tracer'
 require_relative './basic_decorator'
 # NOTES
 # Datadog interface to send our usual actions
@@ -57,7 +56,6 @@ module EventTracer
 
     private
 
-    attr_reader :decoratee
     alias_method :datadog, :decoratee
 
     def valid_args?(metrics)


### PR DESCRIPTION
There are a few warnings when I add `--warnings` during rspec run:

```
warning: .../lib/event_tracer/appsignal_logger.rb:1: warning: loading in progress, circular require considered harmful - .../lib/event_tracer.rb

.../lib/event_tracer/base_logger.rb:19: warning: method redefined; discarding old logger
```