### PR TITLE
Support dry-configurable 0.12 and earlier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-on: [push, pull_request]
+on: [push]
 jobs:
   tests:
     runs-on: ubuntu-latest
@@ -6,9 +6,18 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
+          - "3.1"
           - "3.0"
           - "2.7"
           - "2.6"
+        gemfile:
+          - "Gemfile.dry-config.0.12"
+          - "Gemfile.dry-config.0.14"
+        exclude:
+          - ruby: "2.6"
+            gemfile: "Gemfile.dry-config.0.14"
+    env:
+      BUNDLE_GEMFILE: "${{ matrix.gemfile }}"
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /vendor/bundle/
 *.gem
 Gemfile.lock
+Gemfile.*.lock
 .tool-versions
 
 # rspec failure tracking

--- a/Gemfile.dry-config.0.12
+++ b/Gemfile.dry-config.0.12
@@ -1,0 +1,15 @@
+source "https://rubygems.org"
+
+git_source(:github) {|repo_name| "https://github.com/melvrickgoh/event_tracer" }
+
+# Specify your gem's dependencies in event_tracer.gemspec
+gemspec
+
+gem 'dry-configurable', '0.12'
+
+group :test do
+  gem 'aws-sdk-dynamodb'
+  gem 'nokogiri'
+  gem 'sidekiq'
+  gem 'timecop'
+end

--- a/Gemfile.dry-config.0.14
+++ b/Gemfile.dry-config.0.14
@@ -1,0 +1,15 @@
+source "https://rubygems.org"
+
+git_source(:github) {|repo_name| "https://github.com/melvrickgoh/event_tracer" }
+
+# Specify your gem's dependencies in event_tracer.gemspec
+gemspec
+
+gem 'dry-configurable', '0.14'
+
+group :test do
+  gem 'aws-sdk-dynamodb'
+  gem 'nokogiri'
+  gem 'sidekiq'
+  gem 'timecop'
+end

--- a/lib/event_tracer/config.rb
+++ b/lib/event_tracer/config.rb
@@ -1,14 +1,24 @@
 require 'dry-configurable'
+require 'dry/configurable/version'
 
 module EventTracer
   class Config
     extend Dry::Configurable
 
-    setting :app_name, default: 'app_name'
+    if Dry::Configurable::VERSION >= "0.13"
+      setting :app_name, default: 'app_name'
 
-    # TODO: switch to namespace in v1.0
-    setting :dynamo_db_table_name, default: 'logs'
-    setting :dynamo_db_client
-    setting :dynamo_db_queue_name, default: 'low'
+      # TODO: switch to namespace in v1.0
+      setting :dynamo_db_table_name, default: 'logs'
+      setting :dynamo_db_client
+      setting :dynamo_db_queue_name, default: 'low'
+    else
+      setting :app_name, 'app_name'
+
+      # TODO: switch to namespace in v1.0
+      setting :dynamo_db_table_name, 'logs'
+      setting :dynamo_db_client
+      setting :dynamo_db_queue_name, 'low'
+    end
   end
 end

--- a/lib/event_tracer/version.rb
+++ b/lib/event_tracer/version.rb
@@ -1,3 +1,3 @@
 module EventTracer
-  VERSION = '0.4.3'.freeze
+  VERSION = '0.4.4'.freeze
 end

--- a/spec/data_helpers/mock_appsignal.rb
+++ b/spec/data_helpers/mock_appsignal.rb
@@ -1,4 +1,4 @@
-class MockAppsignal < Struct.new(:_)
+class MockAppsignal
   def increment_counter(*_args); 'increment_counter'; end
   def add_distribution_value(*_args); 'add_distribution_value'; end
   def set_gauge(*_args); 'set_gauge'; end

--- a/spec/event_tracer/appsignal_logger_spec.rb
+++ b/spec/event_tracer/appsignal_logger_spec.rb
@@ -131,7 +131,7 @@ describe EventTracer::AppsignalLogger do
     it 'processes each hash keyset as a metric iteration' do
       expect(mock_appsignal).to receive(:set_gauge).with(:metric_1, 100, { tenant_id: 'any_tenant' })
       expect(mock_appsignal).to receive(:increment_counter).with(:metric_2, 1, { tenant_id: 'any_tenant' })
-      expect(mock_appsignal).to receive(:add_distribution_value).with(:metric_3, 10, tenant_id: 'any_tenant')
+      expect(mock_appsignal).to receive(:add_distribution_value).with(:metric_3, 10, { tenant_id: 'any_tenant' })
 
       result = subject.send(expected_call, **params)
 


### PR DESCRIPTION
Some applications still use older dry-configurable due to newer versions are incompatible with Hanami. 