### PR TITLE
Allow custom metrics with string keys

### DIFF
--- a/lib/event_tracer/appsignal_logger.rb
+++ b/lib/event_tracer/appsignal_logger.rb
@@ -43,8 +43,9 @@ module EventTracer
           end
         when Hash
           metrics.each do |metric_name, metric_payload|
-            metric_type = SUPPORTED_METRIC_TYPES[metric_payload.fetch(:type).to_sym]
-            appsignal.public_send(metric_type, metric_name, metric_payload.fetch(:value), tags) if metric_type
+            payload = metric_payload.transform_keys(&:to_sym)
+            metric_type = SUPPORTED_METRIC_TYPES[payload.fetch(:type).to_sym]
+            appsignal.public_send(metric_type, metric_name, payload.fetch(:value), tags) if metric_type
           end
         end
 

--- a/lib/event_tracer/datadog_logger.rb
+++ b/lib/event_tracer/datadog_logger.rb
@@ -45,8 +45,9 @@ module EventTracer
           end
         when Hash
           metrics.each do |metric_name, metric_payload|
-            metric_type = SUPPORTED_METRIC_TYPES[metric_payload.fetch(:type).to_sym]
-            datadog.public_send(metric_type, metric_name, metric_payload.fetch(:value), tags: tags) if metric_type
+            payload = metric_payload.transform_keys(&:to_sym)
+            metric_type = SUPPORTED_METRIC_TYPES[payload.fetch(:type).to_sym]
+            datadog.public_send(metric_type, metric_name, payload.fetch(:value), tags: tags) if metric_type
           end
         end
 

--- a/lib/event_tracer/version.rb
+++ b/lib/event_tracer/version.rb
@@ -1,3 +1,3 @@
 module EventTracer
-  VERSION = '0.4.5'.freeze
+  VERSION = '0.4.6'.freeze
 end

--- a/spec/event_tracer/appsignal_logger_spec.rb
+++ b/spec/event_tracer/appsignal_logger_spec.rb
@@ -123,7 +123,7 @@ describe EventTracer::AppsignalLogger do
     let(:metrics) do
       {
         metric_1: { type: :gauge, value: 100 },
-        metric_2: { type: :counter, value: 1 },
+        metric_2: { 'type' => :counter, 'value' => 1 },
         metric_3: { type: :distribution, value: 10 }
       }
     end

--- a/spec/event_tracer/datadog_logger_spec.rb
+++ b/spec/event_tracer/datadog_logger_spec.rb
@@ -131,7 +131,7 @@ describe EventTracer::DatadogLogger do
     let(:metrics) do
       {
         metric_1: { type: :gauge, value: 100 },
-        metric_2: { type: :counter, value: 1 },
+        metric_2: { 'type' => :counter, 'value' => 1 },
         metric_3: { type: :distribution, value: 10 },
         metric_4: { type: :set, value: 150 },
         metric_5: { type: :set, value: 50 }


### PR DESCRIPTION
## context

Sidekiq strict arguments requires client app to stringify keys before passing to the worker. While for Event Tracer, the Appsignal and Datadog loggers are requiring symbol keys to send custom metrics.
This PR allows Appsignal and Datadog loggers to work with both string and symbol keys

## test cases

- [ ] Client apps are using the default counter metrics so we can test this by sending custom metrics manually, or observe https://github.com/Kaligo/guardhouse/pull/3457