### PR TITLE
[GHP-1364] feat/add configurable error handler for buffered logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,18 @@ result.records[:base].success? => true
 result.records[:base].error => nil
 ```
 
+Also, specifically for the `BufferedLogger`, `StandardError` is directly rescued and you can provide a proc or instance of a class to handle the error and payloads. You can configure it as such:
+
+```
+EventTracer::Config.configure do |config|
+  config.error_handler = EventTracerExtension::ErrorHandler.new
+end
+```
+
+The error handler will receive two positional arguments, i.e. `EventTracerExtension::ErrorHandler.new.call(error, payloads)`:
+`error` - the rescued error
+`payloads` - the original payloads that were logged
+
 ### Summary
 
 In all the generated interface for `EventTracer` logging could look something like this

--- a/README.md
+++ b/README.md
@@ -214,21 +214,7 @@ EventTracer.register :dynamodb, EventTracer::DynamoDBLogger.new
 
 ### Results
 
-Logging is a side task that should never fail. So we capture any exceptions so that any issue does not impact the flow of your application.
-
-The `EventTracer` returns a `EventTracer::Result` object that logs the success/ failure of the outcome of your execution in case you'd like to investigate why your services ain't working.
-
-Each log result is mapped to the code of the activated logger
-
-**Sample**
-
-```ruby
-result = EventTracer.info action: '123', message: '' # <EventTracer::Result @records={:base=>#<struct EventTracer::LogResult :success?=true, error=nil>}>
-result.records[:base].success? => true
-result.records[:base].error => nil
-```
-
-Also, you can provide a proc or instance of a class to handle the error and payloads. You can configure it as such:
+By default, EventTracer passes through errors that are raised by the loggers. However, you can provide a proc or instance of a class to handle the error and payload. You can configure it as such:
 
 ```
 EventTracer::Config.configure do |config|
@@ -239,6 +225,18 @@ end
 The error handler will receive two positional arguments, i.e. `EventTracerExtension::ErrorHandler.new.call(error, payload)`:
 `error` - the rescued error
 `payload` - the original arguments or payloads that were logged
+
+In addition, it returns a `EventTracer::Result` object that logs the success/failure of the outcome of your execution in case you'd like to investigate why your services ain't working. NOTE: if an error is raised, no results are returned unless you handle the error above.
+
+Each log result is mapped to the code of the activated logger.
+
+**Sample**
+
+```ruby
+result = EventTracer.info action: '123', message: '' # <EventTracer::Result @records={:base=>#<struct EventTracer::LogResult :success?=true, error=nil>}>
+result.records[:base].success? => true
+result.records[:base].error => nil
+```
 
 ### Summary
 

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ result.records[:base].success? => true
 result.records[:base].error => nil
 ```
 
-Also, specifically for the `BufferedLogger`, `StandardError` is directly rescued and you can provide a proc or instance of a class to handle the error and payloads. You can configure it as such:
+Also, you can provide a proc or instance of a class to handle the error and payloads. You can configure it as such:
 
 ```
 EventTracer::Config.configure do |config|
@@ -236,9 +236,9 @@ EventTracer::Config.configure do |config|
 end
 ```
 
-The error handler will receive two positional arguments, i.e. `EventTracerExtension::ErrorHandler.new.call(error, payloads)`:
+The error handler will receive two positional arguments, i.e. `EventTracerExtension::ErrorHandler.new.call(error, payload)`:
 `error` - the rescued error
-`payloads` - the original payloads that were logged
+`payload` - the original arguments or payloads that were logged
 
 ### Summary
 

--- a/lib/event_tracer.rb
+++ b/lib/event_tracer.rb
@@ -35,7 +35,7 @@ module EventTracer
           begin
             result.record code, logger.send(log_type, **args)
           rescue EventTracer::ErrorWithPayload => error
-            EventTracer::Config.config.error_handler.call(error, error.payload)
+            EventTracer::Config.config.error_handler.call(error.cause || error, error.payload)
             result.record code, LogResult.new(false, error.message)
           rescue StandardError => error
             EventTracer::Config.config.error_handler.call(error, args)

--- a/lib/event_tracer/buffered_logger.rb
+++ b/lib/event_tracer/buffered_logger.rb
@@ -46,8 +46,8 @@ module EventTracer
       )
 
       worker.perform_async(filtered_payloads) if filtered_payloads.any?
-    rescue StandardError => e
-      EventTracer::Config.config.error_handler.call(e, payloads)
+    rescue StandardError => error
+      raise EventTracer::ErrorWithPayload.new(error, payloads)
     end
 
     def filter_invalid_data(payloads)

--- a/lib/event_tracer/buffered_logger.rb
+++ b/lib/event_tracer/buffered_logger.rb
@@ -46,6 +46,8 @@ module EventTracer
       )
 
       worker.perform_async(filtered_payloads) if filtered_payloads.any?
+    rescue StandardError => e
+      EventTracer::Config.config.error_handler.call(e, payloads)
     end
 
     def filter_invalid_data(payloads)

--- a/lib/event_tracer/config.rb
+++ b/lib/event_tracer/config.rb
@@ -12,6 +12,7 @@ module EventTracer
       setting :dynamo_db_table_name, default: 'logs'
       setting :dynamo_db_client
       setting :dynamo_db_queue_name, default: 'low'
+      setting :error_handler, default: ->(error, _payloads) { raise error }
     else
       setting :app_name, 'app_name'
 
@@ -19,6 +20,7 @@ module EventTracer
       setting :dynamo_db_table_name, 'logs'
       setting :dynamo_db_client
       setting :dynamo_db_queue_name, 'low'
+      setting :error_handler, ->(error, _payloads) { raise error }
     end
   end
 end

--- a/lib/event_tracer/config.rb
+++ b/lib/event_tracer/config.rb
@@ -12,7 +12,7 @@ module EventTracer
       setting :dynamo_db_table_name, default: 'logs'
       setting :dynamo_db_client
       setting :dynamo_db_queue_name, default: 'low'
-      setting :error_handler, default: ->(error, _payloads) { raise error }
+      setting :error_handler, default: ->(_error, _payload) {}
     else
       setting :app_name, 'app_name'
 
@@ -20,7 +20,7 @@ module EventTracer
       setting :dynamo_db_table_name, 'logs'
       setting :dynamo_db_client
       setting :dynamo_db_queue_name, 'low'
-      setting :error_handler, ->(error, _payloads) { raise error }
+      setting :error_handler, ->(_error, _payload) {}
     end
   end
 end

--- a/lib/event_tracer/config.rb
+++ b/lib/event_tracer/config.rb
@@ -12,7 +12,7 @@ module EventTracer
       setting :dynamo_db_table_name, default: 'logs'
       setting :dynamo_db_client
       setting :dynamo_db_queue_name, default: 'low'
-      setting :error_handler, default: ->(_error, _payload) {}
+      setting :error_handler, default: ->(error, _payload) { raise error }
     else
       setting :app_name, 'app_name'
 
@@ -20,7 +20,7 @@ module EventTracer
       setting :dynamo_db_table_name, 'logs'
       setting :dynamo_db_client
       setting :dynamo_db_queue_name, 'low'
-      setting :error_handler, ->(_error, _payload) {}
+      setting :error_handler, ->(error, _payload) { raise error }
     end
   end
 end

--- a/lib/event_tracer/error_with_payload.rb
+++ b/lib/event_tracer/error_with_payload.rb
@@ -1,0 +1,10 @@
+module EventTracer
+  class ErrorWithPayload < StandardError
+    attr_reader :payload
+
+    def initialize(error, payload)
+      super(error)
+      @payload = payload
+    end
+  end
+end

--- a/lib/event_tracer/version.rb
+++ b/lib/event_tracer/version.rb
@@ -1,3 +1,3 @@
 module EventTracer
-  VERSION = '0.4.6'.freeze
+  VERSION = '0.5.0'.freeze
 end

--- a/spec/data_helpers/mock_logger.rb
+++ b/spec/data_helpers/mock_logger.rb
@@ -2,4 +2,5 @@ class MockLogger < Struct.new(:_)
   def info(*_args); 'info'; end
   def error(*_args); 'error'; end
   def warn(*_args); 'warn'; end
+  def debug(*_args); 'debug'; end
 end

--- a/spec/event_tracer/dynamo_db/worker_spec.rb
+++ b/spec/event_tracer/dynamo_db/worker_spec.rb
@@ -8,6 +8,10 @@ describe EventTracer::DynamoDB::Worker do
     end
   end
 
+  after do
+    EventTracer::Config.reset_config
+  end
+
   let(:details) { { 'action' => 'Test', 'message' => 'Test worker' } }
   let(:aws_dynamo_client) do
     Aws::DynamoDB::Client.new(stub_responses: {

--- a/spec/event_tracer/dynamo_db/worker_spec.rb
+++ b/spec/event_tracer/dynamo_db/worker_spec.rb
@@ -1,6 +1,13 @@
 require 'spec_helper'
 
 describe EventTracer::DynamoDB::Worker do
+  before do
+    EventTracer::Config.configure do |config|
+      config.app_name = 'test_app'
+      config.dynamo_db_table_name = 'test_table'
+    end
+  end
+
   let(:details) { { 'action' => 'Test', 'message' => 'Test worker' } }
   let(:aws_dynamo_client) do
     Aws::DynamoDB::Client.new(stub_responses: {

--- a/spec/event_tracer_spec.rb
+++ b/spec/event_tracer_spec.rb
@@ -64,10 +64,12 @@ describe EventTracer do
     end
 
     it 'marks the logging outcome as false' do
-      expect { subject.send(selected_log_method, **args) }.to raise_error do |error|
-        expect(error).to be_a(RuntimeError)
-        expect(error.message).to eq('Runtime error in base logger')
-      end
+      result = subject.send(selected_log_method, **args)
+      expect(result.records[:base].success?).to eq false
+      expect(result.records[:base].error).to eq 'Runtime error in base logger'
+
+      expect(result.records[:appsignal].success?).to eq true
+      expect(result.records[:appsignal].error).to eq nil
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ require 'data_helpers/mock_datadog'
 require 'event_tracer/dynamo_db/logger'
 require 'dry/configurable/test_interface'
 
+EventTracer::Config.enable_test_interface
 EventTracer::Config.configure do |config|
   config.app_name = 'test_app'
   config.dynamo_db_table_name = 'test_table'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,10 +7,6 @@ require 'event_tracer/dynamo_db/logger'
 require 'dry/configurable/test_interface'
 
 EventTracer::Config.enable_test_interface
-EventTracer::Config.configure do |config|
-  config.app_name = 'test_app'
-  config.dynamo_db_table_name = 'test_table'
-end
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
@@ -19,4 +15,6 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
+
+  config.order = :random
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ require 'data_helpers/mock_logger'
 require 'data_helpers/mock_appsignal'
 require 'data_helpers/mock_datadog'
 require 'event_tracer/dynamo_db/logger'
+require 'dry/configurable/test_interface'
 
 EventTracer::Config.configure do |config|
   config.app_name = 'test_app'


### PR DESCRIPTION
Add a configurable error handler for `BufferedLogger`. 

We could consider handling errors for all logging types, but two issues:
- it'd probably make sense to use inheritance for that so that the BaseLogger could be where we handle the error
- I wonder what would be the best strategy for the app to re-log the logging error, e.g. if Appsignal is not working, then trying to send another Appsignal log wouldn't work.