### PR TITLE
Fix data race in Buffer class

### DIFF
--- a/lib/event_tracer/version.rb
+++ b/lib/event_tracer/version.rb
@@ -1,3 +1,3 @@
 module EventTracer
-  VERSION = '0.6.0'.freeze
+  VERSION = '0.6.1'.freeze
 end

--- a/spec/event_tracer/buffer_spec.rb
+++ b/spec/event_tracer/buffer_spec.rb
@@ -49,6 +49,22 @@ describe EventTracer::Buffer do
         end
       end
     end
+
+    context 'when an instance is called in multiple threads' do
+      it 'works properly' do
+        buffer = described_class.new(buffer_size: 3, flush_interval: 3)
+
+        threads = 10.times.map do |i|
+          Thread.new {
+            10.times do
+              buffer.flush unless buffer.add(i)
+            end
+          }
+        end
+
+        threads.each(&:join)
+      end
+    end
   end
 
   describe '#flush' do


### PR DESCRIPTION
## Context

When we use `buffer.empty?`, followed by `buffer.first`, it can be interrupted by a call to `buffer.shift` in `#flush` by another thread. In that case, it's possible for `buffer.first` to return `nil` and crash the process.

We replace `buffer.empty?` here by using only `buffer.first` to check whether the array is empty, so we don't have to query array state twice.

## Caveats

In the future, it may be better to use a mutex here to ensure data consistency. However, that could become an issue in term of performance. I wonder we could use `Thread.current` to store the buffer, so that we can have a separate buffer for each thread instead. The downside of this approach is that we can have memory leak when the buffer object is misused.