### PR TITLE
[GHP-1777][BE] Do not log if payload is nil

### DIFF
--- a/lib/event_tracer/buffered_logger.rb
+++ b/lib/event_tracer/buffered_logger.rb
@@ -23,7 +23,7 @@ module EventTracer
     def save_message(log_type, action:, message:, **args)
       payload = log_processor.call(log_type, action: action, message: message, args: args)
 
-      unless buffer.add(payload)
+      unless payload.nil? || buffer.add(payload)
         all_payloads = buffer.flush + [payload]
         execute_payload(all_payloads)
       end

--- a/spec/event_tracer/buffered_logger_spec.rb
+++ b/spec/event_tracer/buffered_logger_spec.rb
@@ -28,6 +28,30 @@ describe EventTracer::BufferedLogger do
     it { is_expected.to be_success }
   end
 
+  context 'when payload is nil' do
+    let(:payload) { nil }
+
+    context 'when buffer is not full' do
+      before do
+        expect(buffer).to receive(:size).twice.and_return(0)
+      end
+
+      it 'does nothing' do
+        expect {
+          expect(subject).to be_success
+        }.not_to change { buffer.size }
+      end
+    end
+
+    context 'does nothing' do
+      it 'should not log' do
+        expect(worker).not_to receive(:perform_async)
+
+        subject
+      end
+    end
+  end
+
   context 'when buffer is full and there are no JSON error' do
     let(:all_payloads) { [other_payload, payload] }
     let(:other_payload) { { data: 'other' } }


### PR DESCRIPTION
## design

- In GH if we add a condition to log only if `success: false`, `success: true` or when success tag is not provided will result to payload to be `nil` and will still be added to buffer by ET. 

```ruby 
# GH - lib/event_tracer_extensions/fraud_detection_logger.rb
unless args[:success].nil? || args[:success]
  payload = Hanami::Logger::Filter.new(Constants::FILTERED_PARAMS).call(args)
    .merge('action' => action, 'app' => EventTracer::Config.config.app_name)

  ::Utils::Hash.to_safe_sidekiq_hash(payload)
end
```

```ruby
# ET - lib/event_tracer/buffered_logger.rb
payload = log_processor.call(log_type, action: action, message: message, args: args) # nil

unless buffer.add(payload)
  all_payloads = buffer.flush + [payload]
  execute_payload(all_payloads)
end
```

- This PR adds an additional condition such that the payload will not be processed if it's `nil`
