### PR TITLE
Fix another race condition bug for Buffer class

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,4 +1,3 @@
---format documentation
 --color
 --require spec_helper
 --warnings

--- a/lib/event_tracer/buffer.rb
+++ b/lib/event_tracer/buffer.rb
@@ -43,7 +43,17 @@ module EventTracer
     def flush
       data = []
 
-      data << buffer.shift[:item] until buffer.empty?
+      while buffer.any?
+        item = buffer.shift
+
+        # NOTE: we still need to check this because there can be
+        # race condition, when in another thread `buffer.shift` is called
+        # right after `buffer.any?` and right before `buffer.shift` is called
+        # in this thread.
+        if item
+          data << item[:item]
+        end
+      end
 
       data
     end

--- a/lib/event_tracer/buffer.rb
+++ b/lib/event_tracer/buffer.rb
@@ -43,16 +43,9 @@ module EventTracer
     def flush
       data = []
 
-      while buffer.any?
-        item = buffer.shift
-
-        # NOTE: we still need to check this because there can be
-        # race condition, when in another thread `buffer.shift` is called
-        # right after `buffer.any?` and right before `buffer.shift` is called
-        # in this thread.
-        if item
-          data << item[:item]
-        end
+      # NOTE: We need to use this to avoid race-condition
+      buffer.cycle do
+        data << buffer.shift[:item]
       end
 
       data

--- a/spec/event_tracer/buffer_spec.rb
+++ b/spec/event_tracer/buffer_spec.rb
@@ -91,9 +91,10 @@ describe EventTracer::Buffer do
 
     context 'when an instance is called in multiple threads' do
       let(:buffer_size) { 100 }
+      let(:data) { buffer_size.times.map { |i| "item_#{i}" } }
 
       before do
-        buffer_size.times { |i| buffer.add("item_#{i}") }
+        data.each { |item| buffer.add(item) }
       end
 
       it 'works properly' do
@@ -101,9 +102,10 @@ describe EventTracer::Buffer do
           Thread.new { buffer.flush }
         end
 
-        threads.each(&:join)
+        returned_data = threads.map(&:join).map(&:value).reduce(:+)
 
         expect(buffer.size).to eq 0
+        expect(returned_data).to match_array(data)
       end
     end
   end

--- a/spec/event_tracer_spec.rb
+++ b/spec/event_tracer_spec.rb
@@ -98,8 +98,10 @@ describe EventTracer do
         end
 
         context 'when there is a configured error handler' do
+          let(:io) { StringIO.new }
+
           before do
-            EventTracer::Config.config.error_handler = ->(error, payload) { puts error, payload }
+            EventTracer::Config.config.error_handler = ->(error, payload) { io.puts error, payload }
           end
 
           after do
@@ -113,6 +115,8 @@ describe EventTracer do
 
             expect(result.records[:appsignal].success?).to eq true
             expect(result.records[:appsignal].error).to eq nil
+
+            expect(io.string).to include('Runtime error in base logger')
           end
         end
       end


### PR DESCRIPTION
## Context

Similar to https://github.com/Kaligo/event_tracer/pull/24, we also have a bug in this piece of code:

```ruby
data << buffer.shift[:item] until buffer.empty?
```

The problem with this line is that if there is another thread that runs concurrently and also flush `buffer`, `buffer.shift` can be `nil` even though previous check for `buffer.empty?` returns `false`. To fix this, we need to check whether the result of `#shift` is `nil` or not.

## Caveats

This seems like a band-aid approach than a proper fix. We already saw this issue twice in 2 different places. We may want to have a better concurrent data structure to support this kind of storage.