### PR TITLE
Fix typo in README & code inline comments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ gemspec
 
 group :test do
   gem 'aws-sdk-dynamodb'
-  gem 'debug'
   gem 'nokogiri'
   gem 'prometheus-client'
   gem 'sidekiq'

--- a/Gemfile
+++ b/Gemfile
@@ -1,14 +1,13 @@
-source "https://rubygems.org"
-
-git_source(:github) {|repo_name| "https://github.com/melvrickgoh/event_tracer" }
+source 'https://rubygems.org'
 
 # Specify your gem's dependencies in event_tracer.gemspec
 gemspec
 
 group :test do
   gem 'aws-sdk-dynamodb'
+  gem 'debug'
   gem 'nokogiri'
+  gem 'prometheus-client'
   gem 'sidekiq'
   gem 'timecop'
-  gem 'prometheus-client'
 end

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ EventTracer.info(
   message: 'There is an action',
   metrics: {
     metric_1: { type: :counter, value: 12 },
-    metric_2: { type: :gauce, value: 1 },
+    metric_2: { type: :gauge, value: 1 },
     metric_3: { type: :distribution, value: 10 }
   }
 )
@@ -131,7 +131,7 @@ Appsignal >= 2.5 is currently supported for the following metric functions:
 |------------------------|-----------------|
 | increment_counter      | counter         |
 | add_distribution_value | distribution    |
-| set_gauge              | gauce           |
+| set_gauge              | gauge           |
 
 We can also add [tags](https://docs.appsignal.com/metrics/custom.html#metric-tags) for metric:
 
@@ -232,7 +232,7 @@ registry = if Sidekiq.server?
            else
              Prometheus.registry
            end
-           
+
 logger = EventTracer::Prometheus.new(registry, allowed_tags: [], default_tags: {})
 EventTracer.register :prometheus, logger
 ```
@@ -242,16 +242,16 @@ Then you can track your metrics using the same interface that `EventTracer` prov
 *Notes*
 - For multi-processes app, we need to choose the `DirectFileStore` for Prometheus's data store. Read on [Data store](https://github.com/prometheus/client_ruby#data-stores) for more information.
 
-- Prometheus requires every metrics to be pre-registered before we can track them. In `EventTracer`, by default it will raise the error for any unregistered metrics. Alternative, we provide a `raise_if_missing` flag to allow just-in-time metric registration. 
+- Prometheus requires every metrics to be pre-registered before we can track them. In `EventTracer`, by default it will raise the error for any unregistered metrics. Alternative, we provide a `raise_if_missing` flag to allow just-in-time metric registration.
 ```ruby
 logger = EventTracer::Prometheus.new(
-    registry, 
-    allowed_tags: [], 
+    registry,
+    allowed_tags: [],
     default_tags: {},
     raise_if_missing: false # this will register the missing metric instead of raising error
 )
 ```
-However, doing so defeats the purpose of being clear on what metrics we want to track and can also result in a performance penalty. 
+However, doing so defeats the purpose of being clear on what metrics we want to track and can also result in a performance penalty.
 To make the metrics registration less tedious, we recommend you to standardize your custom metrics name.
 
 ### Results

--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/melvrickgoh/event_tracer.
+Bug reports and pull requests are welcome on GitHub at https://github.com/Kaligo/event_tracer.
 
 ## License
 

--- a/lib/event_tracer/appsignal_logger.rb
+++ b/lib/event_tracer/appsignal_logger.rb
@@ -8,7 +8,7 @@ require_relative './metric_logger'
 #          EventTracer::AppsignalLogger.new(Appsignal, allowed_tags: ['tag_1', 'tag_2'])
 #
 #        appsignal_logger.info metrics: [:counter_1, :counter_2]
-#        appsignal_logger.info metrics: { counter_1: { type: :counter, value: 1 }, gauce_2: { type: :gauce, value: 10 } }
+#        appsignal_logger.info metrics: { counter_1: { type: :counter, value: 1 }, gauge_2: { type: :gauge, value: 10 } }
 module EventTracer
   class AppsignalLogger < MetricLogger
 

--- a/lib/event_tracer/buffered_logger.rb
+++ b/lib/event_tracer/buffered_logger.rb
@@ -37,7 +37,7 @@ module EventTracer
       filtered_payloads = filter_invalid_data(payloads)
 
       EventTracer.warn(
-        loggers: %i(base),
+        loggers: %i[base],
         action: self.class.name,
         app: EventTracer::Config.config.app_name,
         error: e.class.name,
@@ -46,12 +46,16 @@ module EventTracer
       )
 
       worker.perform_async(filtered_payloads) if filtered_payloads.any?
-    rescue StandardError => error
-      raise EventTracer::ErrorWithPayload.new(error, payloads)
+    rescue StandardError => e
+      raise EventTracer::ErrorWithPayload.new(e, payloads)
     end
 
     def filter_invalid_data(payloads)
-      payloads.select { |payload| payload.to_json rescue false }
+      payloads.select do |payload|
+        payload.to_json
+      rescue StandardError
+        false
+      end
     end
   end
 end

--- a/lib/event_tracer/dynamo_db/default_processor.rb
+++ b/lib/event_tracer/dynamo_db/default_processor.rb
@@ -3,11 +3,11 @@ module EventTracer
     class DefaultProcessor
       def call(log_type, action:, message:, args:)
         args.merge(
-          timestamp: Time.now.utc.iso8601(6),
-          action: action,
-          message: message,
-          log_type: log_type,
-          app: EventTracer::Config.config.app_name
+          'timestamp' => Time.now.utc.iso8601(6),
+          'action' => action,
+          'message' => message,
+          'log_type' => log_type.to_s,
+          'app' => EventTracer::Config.config.app_name
         )
       end
     end

--- a/spec/event_tracer/dynamo_db/logger_spec.rb
+++ b/spec/event_tracer/dynamo_db/logger_spec.rb
@@ -19,17 +19,16 @@ describe EventTracer::DynamoDB::Logger do
     let(:payload) do
       {
         message: 'Some message',
-        action: 'Testing',
-        log_type: :info
+        action: 'Testing'
       }
     end
     let(:expected_log_worker_payload) do
       [{
-        message: 'Some message',
-        action: 'Testing',
-        log_type: :info,
-        timestamp: '2020-02-09T12:34:56.000000Z',
-        app: EventTracer::Config.config.app_name
+        'message' => 'Some message',
+        'action' => 'Testing',
+        'log_type' => 'info',
+        'timestamp' => '2020-02-09T12:34:56.000000Z',
+        'app' => EventTracer::Config.config.app_name
       }]
     end
 
@@ -44,8 +43,7 @@ describe EventTracer::DynamoDB::Logger do
     let(:payload) do
       {
         message: "\xAE",
-        action: 'Testing',
-        log_type: :info
+        action: 'Testing'
       }
     end
     let(:expected_log_worker_payload) do
@@ -55,7 +53,13 @@ describe EventTracer::DynamoDB::Logger do
         error: 'JSON::GeneratorError',
         loggers: [:base],
         app: EventTracer::Config.config.app_name,
-        payload: [hash_including(payload)]
+        payload: [
+          hash_including(
+            'log_type' => 'info',
+            'action' => 'Testing',
+            'message' => "\xAE"
+          )
+        ]
       }
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,6 @@ require 'data_helpers/mock_datadog'
 require 'event_tracer/dynamo_db/logger'
 require 'dry/configurable/test_interface'
 require 'prometheus/client'
-require 'debug'
 
 EventTracer::Config.enable_test_interface
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ require 'data_helpers/mock_datadog'
 require 'event_tracer/dynamo_db/logger'
 require 'dry/configurable/test_interface'
 require 'prometheus/client'
+require 'debug'
 
 EventTracer::Config.enable_test_interface
 


### PR DESCRIPTION
### Background

It appears, that instead of "gauge", in several places we had a typo "gauce". This commit fixes it.

### Impact

Minimal, just doc improvement to remove typo.

### Testing

No needed.