### PR TITLE
Implement flush and flush_all APIs for bufferred loggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.6.4
+
+- Add `EventTracer::BufferedLogger#flush` API to immediately flush buffered payloads
+- Add top-level `EventTracer.flush_all` to flush all registered loggers that support flushing
+
 ## 0.6.3
 
 - Fix another data race in `Buffer#flush`

--- a/README.md
+++ b/README.md
@@ -220,6 +220,29 @@ If you prefer not to use the buffer, simply initialize without an argument:
 EventTracer.register :dynamodb, EventTracer::DynamoDBLogger.new
 ```
 
+You can also manually flush any remaining payloads from a buffered logger (e.g. during shutdown) using the new API:
+
+```ruby
+EventTracer.find(:dynamo_db).flush
+```
+This will synchronously drain the buffer and enqueue any remaining payloads to the worker. Invalid JSON payloads are filtered and a warning is emitted with payload context.
+
+To flush all registered loggers that support flushing at once, use the top-level helper:
+
+```ruby
+# In puma initializer
+
+on_worker_shutdown do
+  EventTracer.flush_all
+end
+
+# In Sidekiq initializer
+
+config.on(:shutdown) do
+  EventTracer.flush_all
+end
+```
+
 ### Prometheus integration
 
 - For Ruby app, Prometheus is supported by [Prometheus Client](https://github.com/prometheus/client_ruby). Checkout its [Rack middleware](https://github.com/prometheus/client_ruby#rack-middleware) to setup `/metrics` endpoint.

--- a/lib/event_tracer.rb
+++ b/lib/event_tracer.rb
@@ -25,6 +25,14 @@ module EventTracer
     end
   end
 
+  def self.flush_all
+    @loggers.map do |_code, logger|
+      next unless logger.is_a?(EventTracer::BufferedLogger)
+
+      logger.flush
+    end
+  end
+
   private
 
     def self.send_log_messages(log_type, loggers, args)

--- a/lib/event_tracer/version.rb
+++ b/lib/event_tracer/version.rb
@@ -1,3 +1,3 @@
 module EventTracer
-  VERSION = '0.6.3'.freeze
+  VERSION = '0.6.4'.freeze
 end

--- a/spec/event_tracer/buffered_logger_spec.rb
+++ b/spec/event_tracer/buffered_logger_spec.rb
@@ -9,70 +9,159 @@ describe EventTracer::BufferedLogger do
       worker: worker
     )
   end
-  let(:action) { 'Action' }
-  let(:message) { 'this is a message' }
-  let(:args) { { random_data: 'random' } }
-  let(:payload) { { data: 'data' } }
-  subject { logger.info(action: action, message: message, **args) }
 
-  before do
-    expect(log_processor).to receive(:call)
-      .with(:info, action: action, message: message, args: args).and_return(payload)
-  end
-
-  context 'when buffer is not full' do
-    before do
-      expect(buffer).to receive(:add).with(payload).and_return(true)
-    end
-
-    it { is_expected.to be_success }
-  end
-
-  context 'when buffer is full and there are no JSON error' do
-    let(:all_payloads) { [other_payload, payload] }
-    let(:other_payload) { { data: 'other' } }
+  describe '#info' do
+    let(:action) { 'Action' }
+    let(:message) { 'this is a message' }
+    let(:args) { { random_data: 'random' } }
+    let(:payload) { { data: 'data' } }
+    subject { logger.info(action: action, message: message, **args) }
 
     before do
-      expect(buffer).to receive(:add).with(payload).and_return(false)
-      expect(buffer).to receive(:flush).and_return([other_payload])
-      expect(worker).to receive(:perform_async).with(all_payloads)
+      expect(log_processor).to receive(:call)
+        .with(:info, action: action, message: message, args: args).and_return(payload)
     end
 
-    it { is_expected.to be_success }
+    context 'when buffer is not full' do
+      before do
+        expect(buffer).to receive(:add).with(payload).and_return(true)
+      end
+
+      it { is_expected.to be_success }
+    end
+
+    context 'when buffer is full and there are no JSON error' do
+      let(:all_payloads) { [other_payload, payload] }
+      let(:other_payload) { { data: 'other' } }
+
+      before do
+        expect(buffer).to receive(:add).with(payload).and_return(false)
+        expect(buffer).to receive(:flush).and_return([other_payload])
+        expect(worker).to receive(:perform_async).with(all_payloads)
+      end
+
+      it { is_expected.to be_success }
+    end
+
+    context 'when buffer is full and there is JSON generator error' do
+      let(:all_payloads) { [other_payload, payload] }
+      let(:other_payload) { { data: "\xAE" } }
+
+      before do
+        expect(buffer).to receive(:add).with(payload).and_return(false)
+        expect(buffer).to receive(:flush).and_return([other_payload])
+        expect(worker).to receive(:perform_async)
+          .with(all_payloads).and_raise(JSON::GeneratorError.new('invalid json'))
+        expect(worker).to receive(:perform_async).with([payload])
+      end
+
+      it { is_expected.to be_success }
+    end
+
+    context 'when buffer is full and there is sidekiq error' do
+      let(:all_payloads) { [other_payload, payload] }
+      let(:other_payload) { { 'action' => 'action', 'app' => 'guardhouse', 'metrics' => [:metric_1] } }
+
+      before do
+        expect(buffer).to receive(:add).with(payload).and_return(false)
+        expect(buffer).to receive(:flush).and_return([other_payload])
+        expect(worker).to receive(:perform_async)
+          .with(all_payloads).and_raise(ArgumentError)
+      end
+
+      it 'should raise error' do
+        expect { subject }.to raise_error { |error|
+          expect(error).to be_a EventTracer::ErrorWithPayload
+          expect(error.cause).to be_a ArgumentError
+          expect(error.payload).to eq(all_payloads)
+        }
+      end
+    end
   end
 
-  context 'when buffer is full and there is JSON generator error' do
-    let(:all_payloads) { [other_payload, payload] }
-    let(:other_payload) { { data: "\xAE" } }
+  describe '#flush' do
+    subject { logger.flush }
 
-    before do
-      expect(buffer).to receive(:add).with(payload).and_return(false)
-      expect(buffer).to receive(:flush).and_return([other_payload])
-      expect(worker).to receive(:perform_async)
-        .with(all_payloads).and_raise(JSON::GeneratorError)
-      expect(worker).to receive(:perform_async).with([payload])
+    context 'when buffer is empty' do
+      before do
+        expect(buffer).to receive(:flush).and_return([])
+        expect(worker).not_to receive(:perform_async)
+      end
+
+      it 'returns success' do
+        expect(subject).to be_success
+      end
     end
 
-    it { is_expected.to be_success }
-  end
+    context 'when buffer returns nil' do
+      before do
+        expect(buffer).to receive(:flush).and_return(nil)
+        expect(worker).not_to receive(:perform_async)
+      end
 
-  context 'when buffer is full and there is sidekiq error' do
-    let(:all_payloads) { [other_payload, payload] }
-    let(:other_payload) { { 'action' => 'action', 'app' => 'guardhouse', 'metrics' => [:metric_1] } }
-
-    before do
-      expect(buffer).to receive(:add).with(payload).and_return(false)
-      expect(buffer).to receive(:flush).and_return([other_payload])
-      expect(worker).to receive(:perform_async)
-        .with(all_payloads).and_raise(ArgumentError)
+      it 'returns success' do
+        expect(subject).to be_success
+      end
     end
 
-    it 'should raise error' do
-      expect { subject }.to raise_error { |error|
-        expect(error).to be_a EventTracer::ErrorWithPayload
-        expect(error.cause).to be_a ArgumentError
-        expect(error.payload).to eq(all_payloads)
-      }
+    context 'when buffer has payloads' do
+      let(:payloads) { [{ a: 1 }, { b: 2 }] }
+
+      before do
+        expect(buffer).to receive(:flush).and_return(payloads)
+        expect(worker).to receive(:perform_async).with(payloads)
+      end
+
+      it 'returns success and enqueues payloads' do
+        expect(subject).to be_success
+      end
+    end
+
+    context 'when there is JSON generator error' do
+      let(:invalid_payload) { { data: "\xAE" } }
+      let(:valid_payload) { { data: 'ok' } }
+      let(:payloads) { [invalid_payload, valid_payload] }
+
+      before do
+        expect(buffer).to receive(:flush).and_return(payloads)
+        expect(worker).to receive(:perform_async)
+          .with(payloads).and_raise(JSON::GeneratorError.new('invalid json'))
+        expect(EventTracer).to receive(:warn).with(hash_including(
+          loggers: [:base],
+          action: 'EventTracer::BufferedLogger',
+          app: EventTracer::Config.config.app_name,
+          error: 'JSON::GeneratorError',
+          payload: [invalid_payload]
+        ))
+        expect(worker).to receive(:perform_async).with([valid_payload])
+      end
+
+      it 'filters invalid payloads and returns success' do
+        expect(subject).to be_success
+      end
+    end
+
+    context 'when there is a non-JSON error' do
+      let(:payloads) { [{ data: 'bad' }] }
+
+      before do
+        expect(buffer).to receive(:flush).and_return(payloads)
+        expect(worker).to receive(:perform_async)
+          .with(payloads).and_raise(ArgumentError, 'boom')
+        expect(EventTracer).to receive(:warn).with(hash_including(
+          loggers: [:base],
+          action: 'EventTracer::BufferedLogger',
+          app: EventTracer::Config.config.app_name,
+          error: 'EventTracer::ErrorWithPayload',
+          message: 'boom',
+          payload: payloads
+        ))
+      end
+
+      it 'does not raise' do
+        expect { subject }.not_to raise_error
+        expect(subject).not_to be_success
+      end
     end
   end
 end

--- a/spec/event_tracer/dynamo_db/worker_spec.rb
+++ b/spec/event_tracer/dynamo_db/worker_spec.rb
@@ -22,7 +22,7 @@ describe EventTracer::DynamoDB::Worker do
   subject { described_class.new(aws_dynamo_client) }
 
   context 'when input is a single item' do
-    let(:batch_write_item) { true }
+    let(:batch_write_item) { { unprocessed_items: {} } }
 
     it 'runs and puts details to dynamo db' do
       subject.perform(details)
@@ -30,7 +30,7 @@ describe EventTracer::DynamoDB::Worker do
   end
 
   context 'when input is an array' do
-    let(:batch_write_item) { true }
+    let(:batch_write_item) { { unprocessed_items: {} } }
     let(:details) { [{ 'action' => 'Test', 'message' => 'TestWorker' }] }
 
     it 'runs and puts details to dynamo db' do
@@ -67,7 +67,7 @@ describe EventTracer::DynamoDB::Worker do
         }
       }
     } }
-    let(:batch_write_item) { true }
+    let(:batch_write_item) { { unprocessed_items: {} } }
 
     it 'does not log item attributes with nil values' do
       expect(aws_dynamo_client).to receive(:batch_write_item).with(


### PR DESCRIPTION
## Context

Currently, apps that use DynamoDB logger cannot use buffer as we fear that any messages that haven't been flushed would be loss when pod shuts down. 

To mitigate this issue, we add a new API `EventTracer.flush_all` flush all messages from all buffer loggers. This allow the application to add the flush logic to Puma/Sidekiq shutdown hook and ensure all logs are processed without being loss